### PR TITLE
Fixed list_dynamictable when domain_id not exist, and use str instead int64 in domain_id

### DIFF
--- a/stadata/main.py
+++ b/stadata/main.py
@@ -321,10 +321,9 @@ class Client(object):
         :param latest:get last data from webapi
         """
         if(not latest):
-            allVariable = pd.read_csv('https://gist.githubusercontent.com/isandyawan/4d3efaeea4608c11b1e22b8a51fd0e4d/raw/allVariable.csv',sep="|")
-            if(not all):
-                domain = [int(numeric_string) for numeric_string in domain]
-                allVariable.loc[allVariable['domain'].isin(domain)]
+            allVariable = pd.read_csv('https://gist.githubusercontent.com/isandyawan/4d3efaeea4608c11b1e22b8a51fd0e4d/raw/allVariable.csv',sep="|",dtype={'domain': str})
+            if(not all):               
+                allVariable = allVariable.loc[allVariable["domain"].isin(domain)]
         else: 
             index = 0
             allVariable = []


### PR DESCRIPTION
As default, when I try to get the domain_id from list_domain, it is a string, for example: `0000`. But in this function list_dynamictable, it parses the domain id as an int, so `0000` becomes `0`. Cmiiw